### PR TITLE
docs: add a page about error sharing

### DIFF
--- a/general-docs/5_error-monitoring/error-sharing.md
+++ b/general-docs/5_error-monitoring/error-sharing.md
@@ -1,0 +1,16 @@
+---
+title: Error Sharing
+slug: error-sharing
+createdAt: 2022-12-19T00:00:00.000Z
+updatedAt: 2022-12-19T00:00:00.000Z
+---
+
+By default, only members in your Highlight workspace will be able to view errors (see [Team Management](/product-features/team-management)). If you'd like to share one-off errors and don't want to invite folks to your workspace, then you can share individual errors.
+
+To share an error, click the share button and then toggle "Allow anyone with the link to view this error".
+
+Untoggling this button removes public access to the error.
+
+## What is shared?
+
+When you share an error, all details about the error are made public. This includes user metadata and stack traces for each error instance.


### PR DESCRIPTION
Adds a page about error sharing for a new sharing button: clicking on "Learn more" will open this page. 

<img width="311" alt="Screenshot 2022-12-19 at 4 36 54 PM" src="https://user-images.githubusercontent.com/17913919/208554573-146065e7-48db-4edd-b2c8-c5ae66f2b27c.png">
