### PR TITLE
remove random slug string

### DIFF
--- a/general-docs/1_index.md
+++ b/general-docs/1_index.md
@@ -1,6 +1,6 @@
 ---
 title: Welcome to Highlight
-slug: 9fDE-welcome-to-highlight
+slug: welcome-to-highlight
 createdAt: 2021-09-10T17:54:08.000Z
 updatedAt: 2022-08-18T22:36:12.000Z
 ---

--- a/general-docs/2_getting-started/1_getting-started-overview.md
+++ b/general-docs/2_getting-started/1_getting-started-overview.md
@@ -1,6 +1,6 @@
 ---
 title: Overview
-slug: XfPw-getting-started
+slug: getting-started
 createdAt: 2021-09-13T22:07:04.000Z
 updatedAt: 2022-04-01T19:52:59.000Z
 ---

--- a/general-docs/2_getting-started/2_frontend-backend-mapping.md
+++ b/general-docs/2_getting-started/2_frontend-backend-mapping.md
@@ -1,6 +1,6 @@
 ---
 title: Fullstack Mapping
-slug: JtnW-backend-sdk
+slug: backend-sdk
 createdAt: 2022-03-28T20:05:46.000Z
 updatedAt: 2022-04-01T20:40:53.000Z
 ---

--- a/general-docs/2_getting-started/backend-sdk/backend-sdk-overview.md
+++ b/general-docs/2_getting-started/backend-sdk/backend-sdk-overview.md
@@ -1,6 +1,6 @@
 ---
 title: Backend Quickstart / Overview
-slug: JtnW-backend-sdk
+slug: backend-sdk
 createdAt: 2022-03-28T20:05:46.000Z
 updatedAt: 2022-04-01T20:40:53.000Z
 ---

--- a/general-docs/2_getting-started/backend-sdk/express.md
+++ b/general-docs/2_getting-started/backend-sdk/express.md
@@ -1,6 +1,6 @@
 ---
 title: Express Backend
-slug: oNqi-express-backend
+slug: express-backend
 createdAt: 2022-04-01T20:28:14.000Z
 updatedAt: 2022-04-15T02:07:22.000Z
 ---

--- a/general-docs/2_getting-started/backend-sdk/firebase.md
+++ b/general-docs/2_getting-started/backend-sdk/firebase.md
@@ -1,6 +1,6 @@
 ---
 title: Firebase Backend
-slug: firebase-backend
+slug: backend
 createdAt: 2022-12-23T00:00:00.000Z
 updatedAt: 2022-12-23T00:00:00.000Z
 ---

--- a/general-docs/2_getting-started/backend-sdk/firebase.md
+++ b/general-docs/2_getting-started/backend-sdk/firebase.md
@@ -1,6 +1,6 @@
 ---
 title: Firebase Backend
-slug: backend
+slug: firebase-backend
 createdAt: 2022-12-23T00:00:00.000Z
 updatedAt: 2022-12-23T00:00:00.000Z
 ---

--- a/general-docs/2_getting-started/backend-sdk/go.md
+++ b/general-docs/2_getting-started/backend-sdk/go.md
@@ -1,6 +1,6 @@
 ---
 title: Go Backend
-slug: OyIG-go-backend
+slug: go-backend
 createdAt: 2022-03-28T20:31:15.000Z
 updatedAt: 2022-04-06T20:22:54.000Z
 ---

--- a/general-docs/2_getting-started/backend-sdk/index.md
+++ b/general-docs/2_getting-started/backend-sdk/index.md
@@ -1,6 +1,6 @@
 ---
 title: Backend / Server
-slug: JtnW-backend-sdk
+slug: backend-sdk
 createdAt: 2022-03-28T20:05:46.000Z
 updatedAt: 2022-04-01T20:40:53.000Z
 ---

--- a/general-docs/2_getting-started/backend-sdk/nextjs.md
+++ b/general-docs/2_getting-started/backend-sdk/nextjs.md
@@ -1,6 +1,6 @@
 ---
 title: Next.js Backend
-slug: Z6oy-nextjs-backend
+slug: nextjs-backend
 createdAt: 2022-10-14T00:37:12.000Z
 updatedAt: 2022-10-14T23:10:11.000Z
 ---

--- a/general-docs/2_getting-started/backend-sdk/nodejs.md
+++ b/general-docs/2_getting-started/backend-sdk/nodejs.md
@@ -1,6 +1,6 @@
 ---
 title: Node.js Backend
-slug: AYlL-nodejs-backend
+slug: nodejs-backend
 createdAt: 2022-10-24T20:36:04.000Z
 updatedAt: 2022-10-25T19:42:49.000Z
 ---

--- a/general-docs/2_getting-started/backend-sdk/trpc.md
+++ b/general-docs/2_getting-started/backend-sdk/trpc.md
@@ -1,6 +1,6 @@
 ---
 title: tRPC Backend
-slug: backend
+slug: tprc-backend
 createdAt: 2022-12-23T00:00:00.000Z
 updatedAt: 2022-12-23T00:00:00.000Z
 ---

--- a/general-docs/2_getting-started/backend-sdk/trpc.md
+++ b/general-docs/2_getting-started/backend-sdk/trpc.md
@@ -1,6 +1,6 @@
 ---
 title: tRPC Backend
-slug: trpc-backend
+slug: backend
 createdAt: 2022-12-23T00:00:00.000Z
 updatedAt: 2022-12-23T00:00:00.000Z
 ---

--- a/general-docs/2_getting-started/client-sdk/1_client-sdk-overview.md
+++ b/general-docs/2_getting-started/client-sdk/1_client-sdk-overview.md
@@ -1,6 +1,6 @@
 ---
 title: Frontend Quickstart / Overview
-slug: 7uAC-client-sdk
+slug: client-sdk
 createdAt: 2022-04-01T19:38:31.000Z
 updatedAt: 2022-05-26T18:53:53.000Z
 ---

--- a/general-docs/2_getting-started/client-sdk/angular.md
+++ b/general-docs/2_getting-started/client-sdk/angular.md
@@ -1,6 +1,6 @@
 ---
 title: Angular
-slug: ir-angular
+slug: angular
 createdAt: 2022-05-26T18:54:36.000Z
 updatedAt: 2022-05-26T18:55:03.000Z
 ---

--- a/general-docs/2_getting-started/client-sdk/angular.md
+++ b/general-docs/2_getting-started/client-sdk/angular.md
@@ -1,6 +1,6 @@
 ---
 title: Angular
-slug: l-ir-angular
+slug: ir-angular
 createdAt: 2022-05-26T18:54:36.000Z
 updatedAt: 2022-05-26T18:55:03.000Z
 ---

--- a/general-docs/2_getting-started/client-sdk/gatsbyjs.md
+++ b/general-docs/2_getting-started/client-sdk/gatsbyjs.md
@@ -1,6 +1,6 @@
 ---
 title: Gatsby.js
-slug: 4TkG-gatsbyjs
+slug: gatsbyjs
 createdAt: 2021-09-13T23:00:44.000Z
 updatedAt: 2022-04-01T19:51:11.000Z
 ---

--- a/general-docs/2_getting-started/client-sdk/html.md
+++ b/general-docs/2_getting-started/client-sdk/html.md
@@ -1,6 +1,6 @@
 ---
 title: HTML
-slug: XgeS-html
+slug: html
 createdAt: 2021-09-13T23:00:58.000Z
 updatedAt: 2022-06-13T22:00:02.000Z
 ---

--- a/general-docs/2_getting-started/client-sdk/index.md
+++ b/general-docs/2_getting-started/client-sdk/index.md
@@ -1,6 +1,6 @@
 ---
 title: Frontend / Client
-slug: 7uAC-client-sdk
+slug: client-sdk
 createdAt: 2022-04-01T19:38:31.000Z
 updatedAt: 2022-05-26T18:53:53.000Z
 ---

--- a/general-docs/2_getting-started/client-sdk/nextjs.md
+++ b/general-docs/2_getting-started/client-sdk/nextjs.md
@@ -1,6 +1,6 @@
 ---
 title: Next.js
-slug: d3G0-nextjs
+slug: nextjs
 createdAt: 2021-09-13T23:00:33.000Z
 updatedAt: 2022-10-18T23:54:07.000Z
 ---

--- a/general-docs/2_getting-started/client-sdk/other.md
+++ b/general-docs/2_getting-started/client-sdk/other.md
@@ -1,6 +1,6 @@
 ---
 title: Other
-slug: CFfn-other
+slug: other
 createdAt: 2021-09-13T23:00:58.000Z
 updatedAt: 2022-04-01T19:51:23.000Z
 ---

--- a/general-docs/2_getting-started/client-sdk/reactjs.md
+++ b/general-docs/2_getting-started/client-sdk/reactjs.md
@@ -1,6 +1,6 @@
 ---
 title: React.js
-slug: reactjs
+slug: 
 createdAt: 2021-09-13T22:48:34.000Z
 updatedAt: 2022-05-26T17:21:00.000Z
 ---

--- a/general-docs/2_getting-started/client-sdk/reactjs.md
+++ b/general-docs/2_getting-started/client-sdk/reactjs.md
@@ -1,6 +1,6 @@
 ---
 title: React.js
-slug: 
+slug: reactjs
 createdAt: 2021-09-13T22:48:34.000Z
 updatedAt: 2022-05-26T17:21:00.000Z
 ---

--- a/general-docs/2_getting-started/client-sdk/shopify.md
+++ b/general-docs/2_getting-started/client-sdk/shopify.md
@@ -1,6 +1,6 @@
 ---
 title: Shopify
-slug: n_JJ-shopify
+slug: shopify
 createdAt: 2021-09-13T23:00:58.000Z
 updatedAt: 2022-08-18T22:41:06.000Z
 ---

--- a/general-docs/2_getting-started/client-sdk/squarespace.md
+++ b/general-docs/2_getting-started/client-sdk/squarespace.md
@@ -1,6 +1,6 @@
 ---
 title: Squarespace
-slug: wSUK-squarespace
+slug: squarespace
 createdAt: 2021-09-13T23:00:58.000Z
 updatedAt: 2022-04-01T19:51:22.000Z
 ---

--- a/general-docs/2_getting-started/client-sdk/sveltekit.md
+++ b/general-docs/2_getting-started/client-sdk/sveltekit.md
@@ -1,6 +1,6 @@
 ---
 title: SvelteKit
-slug: nQvO-sveltekit
+slug: sveltekit
 createdAt: 2021-09-13T23:00:44.000Z
 updatedAt: 2022-04-01T19:51:13.000Z
 ---

--- a/general-docs/2_getting-started/client-sdk/vuejs.md
+++ b/general-docs/2_getting-started/client-sdk/vuejs.md
@@ -1,6 +1,6 @@
 ---
 title: Vue.js
-slug: AmCX-vuejs
+slug: vuejs
 createdAt: 2021-09-13T22:48:48.000Z
 updatedAt: 2022-05-26T17:21:23.000Z
 ---

--- a/general-docs/2_getting-started/client-sdk/webflow.md
+++ b/general-docs/2_getting-started/client-sdk/webflow.md
@@ -1,6 +1,6 @@
 ---
 title: Webflow
-slug: -HLp-webflow
+slug: HLp-webflow
 createdAt: 2021-09-13T23:00:58.000Z
 updatedAt: 2022-04-01T19:51:20.000Z
 ---

--- a/general-docs/2_getting-started/client-sdk/webflow.md
+++ b/general-docs/2_getting-started/client-sdk/webflow.md
@@ -1,6 +1,6 @@
 ---
 title: Webflow
-slug: HLp-webflow
+slug: webflow
 createdAt: 2021-09-13T23:00:58.000Z
 updatedAt: 2022-04-01T19:51:20.000Z
 ---

--- a/general-docs/2_getting-started/client-sdk/wordpress.md
+++ b/general-docs/2_getting-started/client-sdk/wordpress.md
@@ -1,6 +1,6 @@
 ---
 title: WordPress
-slug: lfc5-wordpress
+slug: wordpress
 createdAt: 2021-09-13T23:00:58.000Z
 updatedAt: 2022-04-01T19:51:18.000Z
 ---

--- a/general-docs/2_getting-started/fullstack-frameworks/index.md
+++ b/general-docs/2_getting-started/fullstack-frameworks/index.md
@@ -1,6 +1,6 @@
 ---
 title: Fullstack Frameworks
-slug: eAyE-nextjs-sdk
+slug: nextjs-sdk
 createdAt: 2022-04-01T20:28:06.000Z
 updatedAt: 2022-10-18T22:40:13.000Z
 ---

--- a/general-docs/2_getting-started/fullstack-frameworks/next-js/1_overview.md
+++ b/general-docs/2_getting-started/fullstack-frameworks/next-js/1_overview.md
@@ -1,6 +1,6 @@
 ---
 title: Next.js Overview
-slug: eAyE-nextjs-sdk
+slug: nextjs-sdk
 createdAt: 2022-04-01T20:28:06.000Z
 updatedAt: 2022-10-18T22:40:13.000Z
 ---

--- a/general-docs/2_getting-started/fullstack-frameworks/next-js/env-variables.md
+++ b/general-docs/2_getting-started/fullstack-frameworks/next-js/env-variables.md
@@ -1,6 +1,6 @@
 ---
 title: Sourcemap Uploading
-slug: eAyE-nextjs-sdk
+slug: nextjs-sdk
 createdAt: 2022-04-01T20:28:06.000Z
 updatedAt: 2022-10-18T22:40:13.000Z
 ---

--- a/general-docs/2_getting-started/fullstack-frameworks/next-js/index.md
+++ b/general-docs/2_getting-started/fullstack-frameworks/next-js/index.md
@@ -1,6 +1,6 @@
 ---
 title: Next.JS
-slug: eAyE-nextjs-sdk
+slug: nextjs-sdk
 createdAt: 2022-04-01T20:28:06.000Z
 updatedAt: 2022-10-18T22:40:13.000Z
 ---

--- a/general-docs/2_getting-started/fullstack-frameworks/next-js/metrics-overview.md
+++ b/general-docs/2_getting-started/fullstack-frameworks/next-js/metrics-overview.md
@@ -1,6 +1,6 @@
 ---
 title: Reporting Metrics
-slug: BN8E-metrics
+slug: metrics
 createdAt: 2022-10-13T18:20:48.000Z
 updatedAt: 2022-10-18T23:30:10.000Z
 ---

--- a/general-docs/2_getting-started/index.md
+++ b/general-docs/2_getting-started/index.md
@@ -1,6 +1,6 @@
 ---
 title: Getting Started
-slug: XfPw-getting-started
+slug: getting-started
 createdAt: 2021-09-13T22:07:04.000Z
 updatedAt: 2022-04-01T19:52:59.000Z
 ---

--- a/general-docs/3_tips/content-security-policy.md
+++ b/general-docs/3_tips/content-security-policy.md
@@ -1,6 +1,6 @@
 ---
 title: Content-Security-Policy
-slug: 9pQt-content-security-policy
+slug: content-security-policy
 createdAt: 2022-03-01T00:39:25.000Z
 updatedAt: 2022-03-01T01:08:28.000Z
 ---

--- a/general-docs/3_tips/index.md
+++ b/general-docs/3_tips/index.md
@@ -1,6 +1,6 @@
 ---
 title: Tips
-slug: XfPw-getting-started
+slug: getting-started
 createdAt: 2021-09-13T22:07:04.000Z
 updatedAt: 2022-04-01T19:52:59.000Z
 ---

--- a/general-docs/3_tips/local-development.md
+++ b/general-docs/3_tips/local-development.md
@@ -1,6 +1,6 @@
 ---
 title: Local Development
-slug: VLqy-local-development
+slug: local-development
 createdAt: 2021-09-14T00:13:05.000Z
 updatedAt: 2022-03-21T18:23:57.000Z
 ---

--- a/general-docs/3_tips/monkey-patches.md
+++ b/general-docs/3_tips/monkey-patches.md
@@ -1,6 +1,6 @@
 ---
 title: Monkey Patches
-slug: XQkt-monkey-patches
+slug: monkey-patches
 createdAt: 2022-01-21T22:53:59.000Z
 updatedAt: 2022-01-21T23:09:14.000Z
 ---

--- a/general-docs/3_tips/performance-impact.md
+++ b/general-docs/3_tips/performance-impact.md
@@ -1,6 +1,6 @@
 ---
 title: Performance Impact
-slug: 9Zwe-performance-impact
+slug: performance-impact
 createdAt: 2021-10-14T00:18:49.000Z
 updatedAt: 2022-08-08T17:50:32.000Z
 ---

--- a/general-docs/3_tips/proxying-highlight.md
+++ b/general-docs/3_tips/proxying-highlight.md
@@ -1,6 +1,6 @@
 ---
 title: Proxying Highlight
-slug: pk96-proxying-highlight
+slug: proxying-highlight
 createdAt: 2021-10-11T21:13:07.000Z
 updatedAt: 2022-01-27T19:51:23.000Z
 ---

--- a/general-docs/3_tips/sessions-search-deep-linking.md
+++ b/general-docs/3_tips/sessions-search-deep-linking.md
@@ -1,6 +1,6 @@
 ---
 title: Session Search Deep Linking
-slug: RXhV-session-search-deep-linking
+slug: session-search-deep-linking
 createdAt: 2022-01-26T19:50:50.000Z
 updatedAt: 2022-01-26T21:38:34.000Z
 ---

--- a/general-docs/3_tips/troubleshooting.md
+++ b/general-docs/3_tips/troubleshooting.md
@@ -1,6 +1,6 @@
 ---
 title: Troubleshooting
-slug: u6Q2-troubleshooting
+slug: troubleshooting
 createdAt: 2022-01-20T23:35:49.000Z
 updatedAt: 2022-01-20T23:42:57.000Z
 ---

--- a/general-docs/3_tips/upgrading-highlight.md
+++ b/general-docs/3_tips/upgrading-highlight.md
@@ -1,6 +1,6 @@
 ---
 title: Upgrading Highlight
-slug: DN_u-upgrading-highlight
+slug: upgrading-highlight
 createdAt: 2021-09-14T00:13:12.000Z
 updatedAt: 2022-03-08T00:55:27.000Z
 ---

--- a/general-docs/4_session-replay/console-messages.md
+++ b/general-docs/4_session-replay/console-messages.md
@@ -1,6 +1,6 @@
 ---
 title: Console Messages
-slug: uMye-console-messages
+slug: console-messages
 createdAt: 2021-09-14T01:47:28.000Z
 updatedAt: 2022-08-11T16:28:21.000Z
 ---

--- a/general-docs/4_session-replay/html-iframe-recording.md
+++ b/general-docs/4_session-replay/html-iframe-recording.md
@@ -1,6 +1,6 @@
 ---
 title: HTML iframe Recording
-slug: Q8GF-html-iframe-recording
+slug: html-iframe-recording
 createdAt: 2022-04-14T16:12:23.000Z
 updatedAt: 2022-04-19T18:48:07.000Z
 ---

--- a/general-docs/4_session-replay/identifying-sessions.md
+++ b/general-docs/4_session-replay/identifying-sessions.md
@@ -1,6 +1,6 @@
 ---
 title: Identifying Users
-slug: cSWW-identifying-users
+slug: identifying-users
 createdAt: 2021-09-13T23:23:20.000Z
 updatedAt: 2022-07-19T21:02:40.000Z
 ---

--- a/general-docs/4_session-replay/index.md
+++ b/general-docs/4_session-replay/index.md
@@ -1,6 +1,6 @@
 ---
 title: Session Replay
-slug: 9fDE-session-replay
+slug: session-replay
 createdAt: 2021-09-10T17:54:08.000Z
 updatedAt: 2022-08-18T22:36:12.000Z
 ---

--- a/general-docs/4_session-replay/live-mode.md
+++ b/general-docs/4_session-replay/live-mode.md
@@ -1,6 +1,6 @@
 ---
 title: Live Mode
-slug: 2McJ-live-mode
+slug: live-mode
 createdAt: 2022-03-21T18:28:39.000Z
 updatedAt: 2022-03-21T23:31:09.000Z
 ---

--- a/general-docs/4_session-replay/network-devtools.md
+++ b/general-docs/4_session-replay/network-devtools.md
@@ -1,6 +1,6 @@
 ---
 title: Network DevTools
-slug: zN30-network-devtools
+slug: network-devtools
 createdAt: 2021-09-14T01:47:18.000Z
 updatedAt: 2022-03-21T18:25:41.000Z
 ---

--- a/general-docs/4_session-replay/privacy.md
+++ b/general-docs/4_session-replay/privacy.md
@@ -1,6 +1,6 @@
 ---
 title: Privacy
-slug: Nwmp-privacy
+slug: privacy
 createdAt: 2021-09-14T17:47:33.000Z
 updatedAt: 2022-08-03T23:29:08.000Z
 ---

--- a/general-docs/4_session-replay/rage-clicks.md
+++ b/general-docs/4_session-replay/rage-clicks.md
@@ -1,6 +1,6 @@
 ---
 title: Rage Clicks
-slug: KkF8-rage-clicks
+slug: rage-clicks
 createdAt: 2021-10-13T01:46:13.000Z
 updatedAt: 2022-08-09T21:26:43.000Z
 ---

--- a/general-docs/4_session-replay/recording-network-requests-and-responses.md
+++ b/general-docs/4_session-replay/recording-network-requests-and-responses.md
@@ -1,6 +1,6 @@
 ---
 title: Recording Network Requests and Responses
-slug: DUnO-recording-network-requests-and-responses
+slug: recording-network-requests-and-responses
 createdAt: 2021-09-14T00:14:21.000Z
 updatedAt: 2022-03-07T22:43:17.000Z
 ---

--- a/general-docs/4_session-replay/session-sharing.md
+++ b/general-docs/4_session-replay/session-sharing.md
@@ -1,6 +1,6 @@
 ---
 title: Session Sharing
-slug: KxMf-session-sharing
+slug: session-sharing
 createdAt: 2021-09-14T01:47:59.000Z
 updatedAt: 2022-01-07T23:15:15.000Z
 ---

--- a/general-docs/4_session-replay/session-shortcut.md
+++ b/general-docs/4_session-replay/session-shortcut.md
@@ -1,6 +1,6 @@
 ---
 title: Session Shortcut
-slug: TF2O-session-shortcut
+slug: session-shortcut
 createdAt: 2021-11-15T20:06:57.000Z
 updatedAt: 2021-11-15T23:43:54.000Z
 ---

--- a/general-docs/4_session-replay/tracking-events.md
+++ b/general-docs/4_session-replay/tracking-events.md
@@ -1,6 +1,6 @@
 ---
 title: Tracking Events
-slug: BNpF-tracking-events
+slug: tracking-events
 createdAt: 2021-09-13T23:23:28.000Z
 updatedAt: 2022-03-21T18:25:39.000Z
 ---

--- a/general-docs/4_session-replay/versioning-sessions.md
+++ b/general-docs/4_session-replay/versioning-sessions.md
@@ -1,6 +1,6 @@
 ---
 title: Versioning Sessions
-slug: 7IcW-versioning-sessions
+slug: versioning-sessions
 createdAt: 2021-09-14T00:14:40.000Z
 updatedAt: 2022-03-21T18:25:40.000Z
 ---

--- a/general-docs/5_error-monitoring/error-sharing.md
+++ b/general-docs/5_error-monitoring/error-sharing.md
@@ -1,6 +1,6 @@
 ---
 title: Error Sharing
-slug: error-sharing
+slug: sharing
 createdAt: 2022-12-19T00:00:00.000Z
 updatedAt: 2022-12-19T00:00:00.000Z
 ---

--- a/general-docs/5_error-monitoring/error-sharing.md
+++ b/general-docs/5_error-monitoring/error-sharing.md
@@ -1,6 +1,6 @@
 ---
 title: Error Sharing
-slug: sharing
+slug: error-sharing
 createdAt: 2022-12-19T00:00:00.000Z
 updatedAt: 2022-12-19T00:00:00.000Z
 ---

--- a/general-docs/5_error-monitoring/grouping-errors.md
+++ b/general-docs/5_error-monitoring/grouping-errors.md
@@ -1,6 +1,6 @@
 ---
 title: Grouping Errors
-slug: nskl-grouping-errors
+slug: grouping-errors
 createdAt: 2022-03-22T15:27:43.000Z
 updatedAt: 2022-06-27T03:34:47.000Z
 ---

--- a/general-docs/5_error-monitoring/index.md
+++ b/general-docs/5_error-monitoring/index.md
@@ -1,6 +1,6 @@
 ---
 title: Error Monitoring
-slug: 9fDE-error-monitoring
+slug: error-monitoring
 createdAt: 2021-09-10T17:54:08.000Z
 updatedAt: 2022-08-18T22:36:12.000Z
 ---

--- a/general-docs/5_error-monitoring/sourcemaps.md
+++ b/general-docs/5_error-monitoring/sourcemaps.md
@@ -1,6 +1,6 @@
 ---
 title: Sourcemaps
-slug: vdq8-sourcemaps
+slug: sourcemaps
 createdAt: 2021-09-13T23:56:14.000Z
 updatedAt: 2022-08-03T19:08:25.000Z
 ---

--- a/general-docs/5_error-monitoring/versioning-errors.md
+++ b/general-docs/5_error-monitoring/versioning-errors.md
@@ -1,6 +1,6 @@
 ---
 title: Versioning Errors
-slug: lXFv-versioning-errors
+slug: versioning-errors
 createdAt: 2021-09-14T00:14:40.000Z
 updatedAt: 2022-03-22T15:27:47.000Z
 ---

--- a/general-docs/6_product-features/alerts.md
+++ b/general-docs/6_product-features/alerts.md
@@ -1,6 +1,6 @@
 ---
 title: Alerts
-slug: 0OM1-alerts
+slug: alerts
 createdAt: 2021-09-14T00:14:56.000Z
 updatedAt: 2021-09-14T19:03:52.000Z
 ---

--- a/general-docs/6_product-features/analytics.md
+++ b/general-docs/6_product-features/analytics.md
@@ -1,6 +1,6 @@
 ---
 title: Analytics
-slug: vmAm-analytics
+slug: analytics
 createdAt: 2021-09-14T01:48:26.000Z
 updatedAt: 2021-09-14T18:54:27.000Z
 ---

--- a/general-docs/6_product-features/canvas.md
+++ b/general-docs/6_product-features/canvas.md
@@ -1,6 +1,6 @@
 ---
 title: Canvas
-slug: -46L-canvas
+slug: 46L-canvas
 createdAt: 2021-10-13T22:55:19.000Z
 updatedAt: 2022-09-29T18:01:58.000Z
 ---

--- a/general-docs/6_product-features/canvas.md
+++ b/general-docs/6_product-features/canvas.md
@@ -1,6 +1,6 @@
 ---
 title: Canvas
-slug: 46L-canvas
+slug: canvas
 createdAt: 2021-10-13T22:55:19.000Z
 updatedAt: 2022-09-29T18:01:58.000Z
 ---

--- a/general-docs/6_product-features/comments.md
+++ b/general-docs/6_product-features/comments.md
@@ -1,6 +1,6 @@
 ---
 title: Comments
-slug: KUJj-comments
+slug: comments
 createdAt: 2021-09-14T00:13:59.000Z
 updatedAt: 2022-04-13T00:10:08.000Z
 ---

--- a/general-docs/6_product-features/cross-origin-iframes.md
+++ b/general-docs/6_product-features/cross-origin-iframes.md
@@ -1,6 +1,6 @@
 ---
 title: Cross Origin Iframe Recording
-slug: origin-iframes
+slug: cross-origin-iframes
 createdAt: 2023-01-06T00:14:06.000Z
 updatedAt: 2023-01-06T16:44:20.000Z
 ---

--- a/general-docs/6_product-features/cross-origin-iframes.md
+++ b/general-docs/6_product-features/cross-origin-iframes.md
@@ -1,6 +1,6 @@
 ---
 title: Cross Origin Iframe Recording
-slug: cross-origin-iframes
+slug: origin-iframes
 createdAt: 2023-01-06T00:14:06.000Z
 updatedAt: 2023-01-06T16:44:20.000Z
 ---

--- a/general-docs/6_product-features/digests.md
+++ b/general-docs/6_product-features/digests.md
@@ -1,6 +1,6 @@
 ---
 title: Digests
-slug: digests
+slug: 
 createdAt: 2022-12-12T00:00:00.000Z
 updatedAt: 2022-12-12T00:00:00.000Z
 ---

--- a/general-docs/6_product-features/digests.md
+++ b/general-docs/6_product-features/digests.md
@@ -1,6 +1,6 @@
 ---
 title: Digests
-slug: 
+slug: digests
 createdAt: 2022-12-12T00:00:00.000Z
 updatedAt: 2022-12-12T00:00:00.000Z
 ---

--- a/general-docs/6_product-features/environments.md
+++ b/general-docs/6_product-features/environments.md
@@ -1,6 +1,6 @@
 ---
 title: Environments
-slug: S1E9-environments
+slug: environments
 createdAt: 2021-09-14T17:42:37.000Z
 updatedAt: 2022-03-09T17:00:11.000Z
 ---

--- a/general-docs/6_product-features/frontend-observability.md
+++ b/general-docs/6_product-features/frontend-observability.md
@@ -1,6 +1,6 @@
 ---
 title: Frontend Observability
-slug: p3DX-frontend-observability
+slug: frontend-observability
 createdAt: 2022-09-12T16:18:27.000Z
 updatedAt: 2022-09-29T18:55:22.000Z
 ---

--- a/general-docs/6_product-features/index.md
+++ b/general-docs/6_product-features/index.md
@@ -1,6 +1,6 @@
 ---
 title: Product Features
-slug: 9fDE-product-features
+slug: product-features
 createdAt: 2021-09-10T17:54:08.000Z
 updatedAt: 2022-08-18T22:36:12.000Z
 ---

--- a/general-docs/6_product-features/keyboard-shortcuts.md
+++ b/general-docs/6_product-features/keyboard-shortcuts.md
@@ -1,6 +1,6 @@
 ---
 title: Keyboard Shortcuts
-slug: eZGZ-keyboard-shortcuts
+slug: keyboard-shortcuts
 createdAt: 2021-09-14T01:48:34.000Z
 updatedAt: 2021-09-14T18:52:20.000Z
 ---

--- a/general-docs/6_product-features/performance-data.md
+++ b/general-docs/6_product-features/performance-data.md
@@ -1,6 +1,6 @@
 ---
 title: Performance Data
-slug: oqd--performance-data
+slug: -performance-data
 createdAt: 2022-01-28T19:43:21.000Z
 updatedAt: 2022-01-28T19:49:08.000Z
 ---

--- a/general-docs/6_product-features/performance-data.md
+++ b/general-docs/6_product-features/performance-data.md
@@ -1,6 +1,6 @@
 ---
 title: Performance Data
-slug: -performance-data
+slug: performance-data
 createdAt: 2022-01-28T19:43:21.000Z
 updatedAt: 2022-01-28T19:49:08.000Z
 ---

--- a/general-docs/6_product-features/segments.md
+++ b/general-docs/6_product-features/segments.md
@@ -1,6 +1,6 @@
 ---
 title: Segments
-slug: 1Dms-segments
+slug: segments
 createdAt: 2021-09-14T01:48:14.000Z
 updatedAt: 2021-09-14T18:55:12.000Z
 ---

--- a/general-docs/6_product-features/session-search.md
+++ b/general-docs/6_product-features/session-search.md
@@ -1,6 +1,6 @@
 ---
 title: Session Search
-slug: ew6H-session-search
+slug: session-search
 createdAt: 2022-05-06T23:05:46.000Z
 updatedAt: 2022-09-12T16:18:46.000Z
 ---

--- a/general-docs/6_product-features/team-management.md
+++ b/general-docs/6_product-features/team-management.md
@@ -1,6 +1,6 @@
 ---
 title: Team Management
-slug: uF_Y-team-management
+slug: team-management
 createdAt: 2021-09-14T01:48:55.000Z
 updatedAt: 2021-12-07T22:42:14.000Z
 ---

--- a/general-docs/6_product-features/user-feedback.md
+++ b/general-docs/6_product-features/user-feedback.md
@@ -1,6 +1,6 @@
 ---
 title: User Feedback
-slug: r8pl-user-feedback
+slug: user-feedback
 createdAt: 2021-09-14T00:14:06.000Z
 updatedAt: 2021-12-10T23:18:41.000Z
 ---

--- a/general-docs/6_product-features/web-vitals.md
+++ b/general-docs/6_product-features/web-vitals.md
@@ -1,6 +1,6 @@
 ---
 title: Web Vitals
-slug: 1Xs5-web-vitals
+slug: web-vitals
 createdAt: 2021-09-14T00:14:06.000Z
 updatedAt: 2022-03-22T16:44:20.000Z
 ---

--- a/general-docs/6_product-features/webgl.md
+++ b/general-docs/6_product-features/webgl.md
@@ -1,6 +1,6 @@
 ---
 title: WebGL
-slug: E-webgl
+slug: webgl
 createdAt: 2022-01-07T20:33:39.000Z
 updatedAt: 2022-07-11T21:04:21.000Z
 ---

--- a/general-docs/6_product-features/webgl.md
+++ b/general-docs/6_product-features/webgl.md
@@ -1,6 +1,6 @@
 ---
 title: WebGL
-slug: on-E-webgl
+slug: E-webgl
 createdAt: 2022-01-07T20:33:39.000Z
 updatedAt: 2022-07-11T21:04:21.000Z
 ---

--- a/general-docs/7_integrations/amplitude-integration.md
+++ b/general-docs/7_integrations/amplitude-integration.md
@@ -1,6 +1,6 @@
 ---
 title: Amplitude Integration
-slug: KIbZ-amplitude-integration
+slug: amplitude-integration
 createdAt: 2021-09-13T23:57:13.000Z
 updatedAt: 2021-09-17T21:52:19.000Z
 ---

--- a/general-docs/7_integrations/clearbit-integration.md
+++ b/general-docs/7_integrations/clearbit-integration.md
@@ -1,6 +1,6 @@
 ---
 title: Clearbit Integration
-slug: EiHq-clearbit-integration
+slug: clearbit-integration
 createdAt: 2022-09-29T20:48:25.000Z
 updatedAt: 2022-10-13T18:04:10.000Z
 ---

--- a/general-docs/7_integrations/electron-integration.md
+++ b/general-docs/7_integrations/electron-integration.md
@@ -1,6 +1,6 @@
 ---
 title: Electron Support
-slug: L9o_-electron-integration
+slug: electron-integration
 createdAt: 2022-09-29T04:16:22.000Z
 updatedAt: 2022-10-13T18:04:13.000Z
 ---

--- a/general-docs/7_integrations/front-plugin.md
+++ b/general-docs/7_integrations/front-plugin.md
@@ -1,6 +1,6 @@
 ---
 title: Front Plugin
-slug: 3jmn-front-plugin
+slug: front-plugin
 createdAt: 2022-09-08T23:51:48.000Z
 updatedAt: 2022-10-12T16:58:46.000Z
 ---

--- a/general-docs/7_integrations/index.md
+++ b/general-docs/7_integrations/index.md
@@ -1,6 +1,6 @@
 ---
 title: Integrations
-slug: eNAV-integrations
+slug: integrations
 createdAt: 2021-09-15T00:00:28.000Z
 updatedAt: 2022-10-13T21:15:18.000Z
 ---

--- a/general-docs/7_integrations/intercom-integration.md
+++ b/general-docs/7_integrations/intercom-integration.md
@@ -1,6 +1,6 @@
 ---
 title: Intercom Integration
-slug: idBC-intercom-integration
+slug: intercom-integration
 createdAt: 2021-12-03T23:56:12.000Z
 updatedAt: 2021-12-09T00:20:50.000Z
 ---

--- a/general-docs/7_integrations/linear-integration.md
+++ b/general-docs/7_integrations/linear-integration.md
@@ -1,6 +1,6 @@
 ---
 title: Linear Integration
-slug: jLzG-linear-integration
+slug: linear-integration
 createdAt: 2022-06-06T01:42:47.000Z
 updatedAt: 2022-06-06T16:45:25.000Z
 ---

--- a/general-docs/7_integrations/mixpanel-integration.md
+++ b/general-docs/7_integrations/mixpanel-integration.md
@@ -1,6 +1,6 @@
 ---
 title: Mixpanel Integration
-slug: 8xnb-mixpanel-integration
+slug: mixpanel-integration
 createdAt: 2021-09-13T23:57:09.000Z
 updatedAt: 2021-12-03T23:56:06.000Z
 ---

--- a/general-docs/7_integrations/reactjs-integration.md
+++ b/general-docs/7_integrations/reactjs-integration.md
@@ -1,6 +1,6 @@
 ---
 title: React.js Integration
-slug: aDYB-reactjs-integration
+slug: reactjs-integration
 createdAt: 2021-09-14T02:03:51.000Z
 updatedAt: 2022-09-08T21:45:54.000Z
 ---

--- a/general-docs/7_integrations/segment-integration.md
+++ b/general-docs/7_integrations/segment-integration.md
@@ -1,6 +1,6 @@
 ---
 title: Segment Integration
-slug: YMjR-segment-integration
+slug: segment-integration
 createdAt: 2021-10-18T22:03:24.000Z
 updatedAt: 2022-06-13T15:44:38.000Z
 ---

--- a/general-docs/7_integrations/sentry-integration.md
+++ b/general-docs/7_integrations/sentry-integration.md
@@ -1,6 +1,6 @@
 ---
 title: Sentry Integration
-slug: ixW4-sentry-integration
+slug: sentry-integration
 createdAt: 2021-10-18T22:03:24.000Z
 updatedAt: 2022-06-01T17:58:57.000Z
 ---

--- a/general-docs/7_integrations/slack-integration.md
+++ b/general-docs/7_integrations/slack-integration.md
@@ -1,6 +1,6 @@
 ---
 title: Slack Integration
-slug: tNao-slack-integration
+slug: slack-integration
 createdAt: 2021-09-17T21:48:44.000Z
 updatedAt: 2021-09-17T21:56:27.000Z
 ---

--- a/general-docs/7_integrations/vercel-integration.md
+++ b/general-docs/7_integrations/vercel-integration.md
@@ -1,6 +1,6 @@
 ---
 title: Vercel Integration
-slug: qpps-vercel-integration
+slug: vercel-integration
 createdAt: 2022-10-13T18:03:19.000Z
 updatedAt: 2022-10-13T18:09:17.000Z
 ---

--- a/general-docs/7_integrations/vercel-integration.md
+++ b/general-docs/7_integrations/vercel-integration.md
@@ -1,6 +1,6 @@
 ---
 title: Vercel Integration
-slug: vercel-integration
+slug: apps-vercel-integration
 createdAt: 2022-10-13T18:03:19.000Z
 updatedAt: 2022-10-13T18:09:17.000Z
 ---


### PR DESCRIPTION
Looks like the slug prefix of a random set of characters doesn't do anything (see [internal docs](https://www.notion.so/Contributing-to-our-Docs-9aef80be272741cd94b785287a2129c6?d=f2e8150f5a3541baaeaa59611220d79d#0ded6b8e99944e878bed136a95973bbd)).

I removed it to avoid confusion in the future. I verified that the docs still load correctly.